### PR TITLE
feat: alternative install

### DIFF
--- a/misc/spout2pw.sh
+++ b/misc/spout2pw.sh
@@ -251,7 +251,6 @@ prepare_prefix() {
 
 }
 
-
 prepare_proton() {
     if ! grep -q 'WINEDLLPATH.*in os.environ' "$protonpath/proton"; then
         fatal "This Proton version is too old to work with Spout2PW.\n\nSpout2PW requires a recent Proton 10."


### PR DESCRIPTION
Two main changes:

-  `|| fatal "Installation failed"` Wouldnt work never be called with proton so removed it.
~~-  if the files are not to be found with first install method it manually copies them, then adds the related registry entries~~


Closes https://github.com/hoshinolina/spout2pw/issues/16