### PR TITLE
Fix shebang

### DIFF
--- a/misc/spout2pw.sh
+++ b/misc/spout2pw.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -E
 
 spout2pw="$(dirname "$(realpath "$0")")"


### PR DESCRIPTION
current shebang only works if bash is located at `/bin/bash`

this PR fixes the shebang to use env instead: `#!/usr/bin/env bash`