### PR TITLE
Fixes for NVIDIA proprietary driver issue on pre-Turing

### DIFF
--- a/src/spout2pw.c
+++ b/src/spout2pw.c
@@ -327,6 +327,7 @@ static struct source_info get_receiver_info(struct receiver *receiver) {
     ret.width = metadata.Width;
     ret.height = metadata.Height;
     ret.format = metadata.Format;
+    ret.bind_flags = metadata.BindFlags;
 
     struct shared_resource_info shared_resource_info;
 

--- a/src/spout2pw_unix.h
+++ b/src/spout2pw_unix.h
@@ -49,6 +49,7 @@ struct source_info
     uint32_t height;
     uint32_t format;
     uint32_t usage;
+    uint32_t bind_flags;
     int32_t opaque_fd;
 };
 


### PR DESCRIPTION
This fixes rendering issues on pre-Turing cards:

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/122747e3-08e2-49c2-b01e-56230ef11009" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a7b8e85a-28e6-48c5-84b3-ef75ba99ebfc" />

/cc @hoshinolina